### PR TITLE
Make createdb step optional

### DIFF
--- a/database/install.sh
+++ b/database/install.sh
@@ -30,7 +30,12 @@ function create-user {
 }
 
 function create-database {
-  createdb $database
+  if [ -z ${SKIP_CREATE_DATABASE+x} ]; then
+    createdb $database
+  else
+    echo "Skipping database creation"
+  fi
+
   echo
 }
 


### PR DESCRIPTION
Allows the user to set a variable that instructs the `install.sh` script to skip creating a database.

The motivation for this change is the desire to use Heroku Postgres. When you establish a new instance of a Heroku Postgres database the actual database is created and the name of that database is provided. Given this fact the `install.sh` script will fail when the `createdb` command is run.

Failure output:

```sh
Creating Database: something
- - -
createdb: could not connect to database template1: FATAL:  permission denied for database "template1"
DETAIL:  User does not have CONNECT privilege.
```

When providing `SKIP_CREATE_DATABASE`:

```sh
Creating Database: something
- - -
Skipping database creation
```