### PR TITLE
Function parameter names are being disambiguated

### DIFF
--- a/database/functions/category.sql
+++ b/database/functions/category.sql
@@ -1,10 +1,10 @@
 CREATE OR REPLACE FUNCTION category(
-  _stream_name varchar
+  stream_name varchar
 )
 RETURNS varchar
 AS $$
 BEGIN
-  return split_part(_stream_name, '-', 1);
+  return split_part(stream_name, '-', 1);
 END;
 $$ LANGUAGE plpgsql
 IMMUTABLE;

--- a/database/functions/get-category-messages.sql
+++ b/database/functions/get-category-messages.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE FUNCTION get_category_messages(
-  _category_name varchar,
-  _position bigint DEFAULT 0,
-  _batch_size bigint DEFAULT 1000,
-  _condition varchar DEFAULT NULL
+  category_name varchar,
+  "position" bigint DEFAULT 0,
+  batch_size bigint DEFAULT 1000,
+  condition varchar DEFAULT NULL
 )
 RETURNS SETOF message
 AS $$
@@ -25,10 +25,10 @@ BEGIN
       category(stream_name) = $1 AND
       global_position >= $2';
 
-  if _condition is not null then
+  if get_category_messages.condition is not null then
     command := command || ' AND
       %s';
-    command := format(command, _condition);
+    command := format(command, get_category_messages.condition);
   end if;
 
   command := command || '
@@ -39,7 +39,7 @@ BEGIN
 
   -- RAISE NOTICE '%', command;
 
-  RETURN QUERY EXECUTE command USING _category_name, _position, _batch_size;
+  RETURN QUERY EXECUTE command USING get_category_messages.category_name, get_category_messages.position, get_category_messages.batch_size;
 END;
 $$ LANGUAGE plpgsql
 VOLATILE;

--- a/database/functions/get-category-messages.sql
+++ b/database/functions/get-category-messages.sql
@@ -39,7 +39,10 @@ BEGIN
 
   -- RAISE NOTICE '%', command;
 
-  RETURN QUERY EXECUTE command USING get_category_messages.category_name, get_category_messages.position, get_category_messages.batch_size;
+  RETURN QUERY EXECUTE command USING
+    get_category_messages.category_name,
+    get_category_messages.position,
+    get_category_messages.batch_size;
 END;
 $$ LANGUAGE plpgsql
 VOLATILE;

--- a/database/functions/get-last-message.sql
+++ b/database/functions/get-last-message.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION get_last_message(
-  _stream_name varchar
+  stream_name varchar
 )
 RETURNS SETOF message
 AS $$
@@ -27,7 +27,7 @@ BEGIN
 
   -- RAISE NOTICE '%', command;
 
-  RETURN QUERY EXECUTE command USING _stream_name;
+  RETURN QUERY EXECUTE command USING get_last_message.stream_name;
 END;
 $$ LANGUAGE plpgsql
 VOLATILE;

--- a/database/functions/get-stream-messages.sql
+++ b/database/functions/get-stream-messages.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE FUNCTION get_stream_messages(
-  _stream_name varchar,
+  stream_name varchar,
   "position" bigint DEFAULT 0,
-  _batch_size bigint DEFAULT 1000,
-  _condition varchar DEFAULT NULL
+  batch_size bigint DEFAULT 1000,
+  condition varchar DEFAULT NULL
 )
 RETURNS SETOF message
 AS $$
@@ -25,10 +25,10 @@ BEGIN
       stream_name = $1 AND
       position >= $2';
 
-  if _condition is not null then
+  if get_stream_messages.condition is not null then
     command := command || ' AND
       %s';
-    command := format(command, _condition);
+    command := format(command, get_stream_messages.condition);
   end if;
 
   command := command || '
@@ -40,9 +40,9 @@ BEGIN
   -- RAISE NOTICE '%', command;
 
   RETURN QUERY EXECUTE command USING
-    get_stream_messages._stream_name,
+    get_stream_messages.stream_name,
     get_stream_messages.position,
-    get_stream_messages._batch_size;
+    get_stream_messages.batch_size;
 END;
 $$ LANGUAGE plpgsql
 VOLATILE;

--- a/database/functions/hash-64.sql
+++ b/database/functions/hash-64.sql
@@ -1,12 +1,12 @@
 CREATE OR REPLACE FUNCTION hash_64(
-  _stream_name varchar
+  stream_name varchar
 )
 RETURNS bigint
 AS $$
 DECLARE
   hash bigint;
 BEGIN
-  select left('x' || md5(_stream_name), 17)::bit(64)::bigint into hash;
+  select left('x' || md5(hash_64.stream_name), 17)::bit(64)::bigint into hash;
   return hash;
 END;
 $$ LANGUAGE plpgsql

--- a/database/functions/write-message.sql
+++ b/database/functions/write-message.sql
@@ -29,7 +29,11 @@ BEGIN
 
   if write_message.expected_version is not null then
     if write_message.expected_version != stream_version then
-      raise exception 'Wrong expected version: % (Stream: %, Stream Version: %)', write_message.expected_version, write_message.stream_name, stream_version;
+      raise exception
+        'Wrong expected version: % (Stream: %, Stream Version: %)',
+        write_message.expected_version,
+        write_message.stream_name,
+        stream_version;
     end if;
   end if;
 

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+test/category.sh
 test/hash-64.sh
 
 test/write-message.sh

--- a/test/category.sh
+++ b/test/category.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo
+echo "GET CATEGORY"
+echo "============"
+echo
+
+source test/controls.sh
+
+stream_name=$(stream-name)
+
+echo "Stream Name:"
+echo $stream_name
+echo
+
+psql message_store -U message_store -x -c "SELECT category('$stream_name');"
+
+echo "= = ="
+echo

--- a/test/get-category-messages.sh
+++ b/test/get-category-messages.sh
@@ -25,7 +25,7 @@ for i in {1..3}; do
 done
 echo
 
-cmd="SELECT * FROM get_category_messages('$category', 0, 2, _condition => 'position >= 1');"
+cmd="SELECT * FROM get_category_messages('$category', 0, 2, condition => 'position >= 1');"
 
 echo "Command:"
 echo "$cmd"

--- a/test/get-stream-messages.sh
+++ b/test/get-stream-messages.sh
@@ -19,7 +19,7 @@ echo
 
 write-message $stream_name 3
 
-cmd="SELECT * FROM get_stream_messages('$stream_name', 0, 2, _condition => 'position >= 1');"
+cmd="SELECT * FROM get_stream_messages('$stream_name', 0, 2, condition => 'position >= 1');"
 
 echo "Command:"
 echo "$cmd"


### PR DESCRIPTION
1. A get category test was added during disambiguation of parameter names in `category` function
2. Hash 64 test is hard (impossible) to inspect for a human. My approach was to run the various SQL commands composing the function manually in `psql`, but I wasn't happy with it. Ideally the tests perform something similar to the `hash_64` function in bash and writes the output close to the SQL output for easy visual comparison
3. `get_stream_messages`, `get_category_messages` and `write_message` are affected in scannability due to the standard of prefixing the function name to the parameter
4. `write_message` function had `raise exception` formatted vertically due to the increased length of the parameter names. The new formatting should keep the string interpolation somewhat scannable

Regarding point **(3)**, this is an example of how scannability is affected:

```sql
  if write_message.expected_version is not null then
    if write_message.expected_version != stream_version then
```

versus the previous one

```sql
  if expected_version is not null then
    if expected_version != stream_version then
```

And considering how sensitive is this part of the code, I'd to suggest to keep the parameters without the prefix within control-flow expressions. I'd be happy to discuss this point further and hear alternative solutions.

I carefully inspected the tests multiple times, but a final inspection is needed since I'm tired and it would be ineffective to perform one now.